### PR TITLE
Reimplement gdt

### DIFF
--- a/src/kernel/gdt/gdt.c
+++ b/src/kernel/gdt/gdt.c
@@ -20,6 +20,7 @@ typedef struct gdt_descriptor gdt_descriptor_t;
 //defined in gdt.s
 extern void gdt_activate(uint32_t* gdt_pointer);
 
+//This implementation was modified from an excerpt on http://wiki.osdev.org/GDT_Tutorial
 // Each define here is for a specific flag in the descriptor.
 // Refer to the intel documentation for a description of what each one does.
 #define SEG_DESCTYPE(x)  ((x) << 0x04) // Descriptor type (0 for system, 1 for code/data)
@@ -82,8 +83,8 @@ static void gdt_write_descriptor(gdt_entry_t* entry, uint32_t base, uint32_t lim
 }
 
 void gdt_init() {
-    static gdt_entry_t gdt_entries[5]        = {0};
-    static gdt_descriptor_t   gdt_descriptor = {0};
+    static gdt_entry_t          gdt_entries[5] = {0};
+    static gdt_descriptor_t     gdt_descriptor = {0};
 
     gdt_descriptor.table_base = (uint32_t)&gdt_entries;
     gdt_descriptor.table_size = sizeof(gdt_entries) - 1;

--- a/src/kernel/gdt/gdt.c
+++ b/src/kernel/gdt/gdt.c
@@ -1,6 +1,22 @@
 #include "gdt.h"
 #include <std/memory.h>
 
+
+//Intel-defined GDT structure formats
+//this structure has a carefully defined format which we must preserve
+//see here for format: http://wiki.osdev.org/Global_Descriptor_Table
+struct gdt_entry {
+    uint32_t low_word;
+    uint32_t high_word;
+} __attribute__((packed));
+typedef struct gdt_entry gdt_entry_t;
+
+struct gdt_descriptor {
+    uint16_t table_size;
+    uint32_t table_base;
+} __attribute__((packed));
+typedef struct gdt_descriptor gdt_descriptor_t;
+
 //defined in gdt.s
 extern void gdt_activate(uint32_t* gdt_pointer);
 

--- a/src/kernel/gdt/gdt.c
+++ b/src/kernel/gdt/gdt.c
@@ -1,0 +1,101 @@
+#include "gdt.h"
+#include <std/memory.h>
+
+#define GDT_SEGMENT_ACCESS_FLAGS_NULL           0x00
+#define GDT_SEGMENT_ACCESS_FLAGS_CS             0x9A
+#define GDT_SEGMENT_ACCESS_FLAGS_DS             0x92
+#define GDT_SEGMENT_ACCESS_FLAGS_USER_CS        0xFA
+#define GDT_SEGMENT_ACCESS_FLAGS_USER_DS        0xF2
+
+#define GDT_SEGMENT_GRANULARITY_FLAGS_NULL      0x00
+#define GDT_SEGMENT_GRANULARITY_FLAGS_CS        0xCF
+#define GDT_SEGMENT_GRANULARITY_FLAGS_DS        0xCF
+#define GDT_SEGMENT_GRANULARITY_FLAGS_USER_CS   0xCF
+#define GDT_SEGMENT_GRANULARITY_FLAGS_USER_DS   0xCF
+
+//defined in gdt.s
+extern void gdt_activate(uint32_t* gdt_pointer);
+
+static void gdt_entry_write_limit_address(gdt_entry_t* ent, uint32_t limit) {
+    ent->limit_low  = limit & 0x0FFFF;
+    ent->limit_high = limit & 0xF0000;
+}
+
+static void gdt_entry_write_base_address(gdt_entry_t* ent, uint32_t base) {
+    ent->base_low  = base & 0x0000FFFF;
+    ent->base_mid  = base & 0x00FF0000;
+    ent->base_high = base & 0xFF000000;
+}
+
+static void gdt_entry_write_access_flags(gdt_entry_t* ent, uint8_t flags) {
+    memcpy(&ent->access_flags, sizeof(uint8_t), &flags);
+}
+
+static void gdt_entry_write_granularity_flags(gdt_entry_t* ent, uint8_t flags) {
+    //toss low nibble
+    //this flag is only 4 bits
+    flags &= 0xF0;
+    memcpy(&ent->granularity_flags, sizeof(uint8_t), &flags);
+}
+
+static void gdt_setup_null_segment(gdt_entry_t* ent) {
+    gdt_entry_write_base_address(ent, 0x00000000);
+    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+
+    memset(&ent->access_flags, 0, sizeof(ent->access_flags));
+    memset(&ent->granularity_flags, 0, sizeof(ent->granularity_flags));
+}
+
+static void gdt_setup_code_segment(gdt_entry_t* ent) {
+    //we must write the granularity flags before the limit address because the granularity flags are only 4 bits,
+    //but in gdt_entry_write_access_flags we copy a full byte to the struct field where the granularity flags are stored
+    //if we'd already written data to the extra 4 bits after the granularity flags, they'd have been overwritten
+    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_CS);
+    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_CS);
+
+    gdt_entry_write_base_address(ent, 0x00000000);
+    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+}
+
+static void gdt_setup_data_segment(gdt_entry_t* ent) {
+    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_DS);
+    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_DS);
+
+    gdt_entry_write_base_address(ent, 0x00000000);
+    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+}
+
+static void gdt_setup_user_code_segment(gdt_entry_t* ent) {
+    //gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_USER_CS);
+    //gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_USER_CS);
+
+    //gdt_entry_write_base_address(ent, 0x00000000);
+    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+}
+
+static void gdt_setup_user_data_segment(gdt_entry_t* ent) {
+    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_USER_DS);
+    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_USER_DS);
+
+    gdt_entry_write_base_address(ent, 0x00000000);
+    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+}
+
+void gdt_init() {
+    static gdt_entry_t gdt_entries[6]        = {0};
+    static gdt_descriptor_t   gdt_descriptor = {0};
+
+    gdt_descriptor.table_base = (uint32_t)&gdt_entries;
+    gdt_descriptor.table_size = sizeof(gdt_entries) - 1;
+
+    gdt_setup_null_segment(&gdt_entries[0]);
+    gdt_setup_code_segment(&gdt_entries[1]);
+    /*
+    gdt_setup_data_segment(&gdt_entries[2]);
+    gdt_setup_user_code_segment(&gdt_entries[3]);
+    gdt_setup_user_data_segment(&gdt_entries[4]);
+    */
+
+    //gdt_activate((uint32_t)&gdt_descriptor);
+}
+

--- a/src/kernel/gdt/gdt.c
+++ b/src/kernel/gdt/gdt.c
@@ -1,101 +1,83 @@
 #include "gdt.h"
 #include <std/memory.h>
 
-#define GDT_SEGMENT_ACCESS_FLAGS_NULL           0x00
-#define GDT_SEGMENT_ACCESS_FLAGS_CS             0x9A
-#define GDT_SEGMENT_ACCESS_FLAGS_DS             0x92
-#define GDT_SEGMENT_ACCESS_FLAGS_USER_CS        0xFA
-#define GDT_SEGMENT_ACCESS_FLAGS_USER_DS        0xF2
-
-#define GDT_SEGMENT_GRANULARITY_FLAGS_NULL      0x00
-#define GDT_SEGMENT_GRANULARITY_FLAGS_CS        0xCF
-#define GDT_SEGMENT_GRANULARITY_FLAGS_DS        0xCF
-#define GDT_SEGMENT_GRANULARITY_FLAGS_USER_CS   0xCF
-#define GDT_SEGMENT_GRANULARITY_FLAGS_USER_DS   0xCF
-
 //defined in gdt.s
 extern void gdt_activate(uint32_t* gdt_pointer);
 
-static void gdt_entry_write_limit_address(gdt_entry_t* ent, uint32_t limit) {
-    ent->limit_low  = limit & 0x0FFFF;
-    ent->limit_high = limit & 0xF0000;
-}
-
-static void gdt_entry_write_base_address(gdt_entry_t* ent, uint32_t base) {
-    ent->base_low  = base & 0x0000FFFF;
-    ent->base_mid  = base & 0x00FF0000;
-    ent->base_high = base & 0xFF000000;
-}
-
-static void gdt_entry_write_access_flags(gdt_entry_t* ent, uint8_t flags) {
-    memcpy(&ent->access_flags, sizeof(uint8_t), &flags);
-}
-
-static void gdt_entry_write_granularity_flags(gdt_entry_t* ent, uint8_t flags) {
-    //toss low nibble
-    //this flag is only 4 bits
-    flags &= 0xF0;
-    memcpy(&ent->granularity_flags, sizeof(uint8_t), &flags);
-}
-
-static void gdt_setup_null_segment(gdt_entry_t* ent) {
-    gdt_entry_write_base_address(ent, 0x00000000);
-    gdt_entry_write_limit_address(ent, 0x000FFFFF);
-
-    memset(&ent->access_flags, 0, sizeof(ent->access_flags));
-    memset(&ent->granularity_flags, 0, sizeof(ent->granularity_flags));
-}
-
-static void gdt_setup_code_segment(gdt_entry_t* ent) {
-    //we must write the granularity flags before the limit address because the granularity flags are only 4 bits,
-    //but in gdt_entry_write_access_flags we copy a full byte to the struct field where the granularity flags are stored
-    //if we'd already written data to the extra 4 bits after the granularity flags, they'd have been overwritten
-    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_CS);
-    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_CS);
-
-    gdt_entry_write_base_address(ent, 0x00000000);
-    gdt_entry_write_limit_address(ent, 0x000FFFFF);
-}
-
-static void gdt_setup_data_segment(gdt_entry_t* ent) {
-    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_DS);
-    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_DS);
-
-    gdt_entry_write_base_address(ent, 0x00000000);
-    gdt_entry_write_limit_address(ent, 0x000FFFFF);
-}
-
-static void gdt_setup_user_code_segment(gdt_entry_t* ent) {
-    //gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_USER_CS);
-    //gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_USER_CS);
-
-    //gdt_entry_write_base_address(ent, 0x00000000);
-    gdt_entry_write_limit_address(ent, 0x000FFFFF);
-}
-
-static void gdt_setup_user_data_segment(gdt_entry_t* ent) {
-    gdt_entry_write_access_flags(ent, GDT_SEGMENT_ACCESS_FLAGS_USER_DS);
-    gdt_entry_write_granularity_flags(ent, GDT_SEGMENT_GRANULARITY_FLAGS_USER_DS);
-
-    gdt_entry_write_base_address(ent, 0x00000000);
-    gdt_entry_write_limit_address(ent, 0x000FFFFF);
+// Each define here is for a specific flag in the descriptor.
+// Refer to the intel documentation for a description of what each one does.
+#define SEG_DESCTYPE(x)  ((x) << 0x04) // Descriptor type (0 for system, 1 for code/data)
+#define SEG_PRES(x)      ((x) << 0x07) // Present
+#define SEG_SAVL(x)      ((x) << 0x0C) // Available for system use
+#define SEG_LONG(x)      ((x) << 0x0D) // Long mode
+#define SEG_SIZE(x)      ((x) << 0x0E) // Size (0 for 16-bit, 1 for 32)
+#define SEG_GRAN(x)      ((x) << 0x0F) // Granularity (0 for 1B - 1MB, 1 for 4KB - 4GB)
+#define SEG_PRIV(x)     (((x) &  0x03) << 0x05)   // Set privilege level (0 - 3)
+ 
+#define SEG_DATA_RD        0x00 // Read-Only
+#define SEG_DATA_RDA       0x01 // Read-Only, accessed
+#define SEG_DATA_RDWR      0x02 // Read/Write
+#define SEG_DATA_RDWRA     0x03 // Read/Write, accessed
+#define SEG_DATA_RDEXPD    0x04 // Read-Only, expand-down
+#define SEG_DATA_RDEXPDA   0x05 // Read-Only, expand-down, accessed
+#define SEG_DATA_RDWREXPD  0x06 // Read/Write, expand-down
+#define SEG_DATA_RDWREXPDA 0x07 // Read/Write, expand-down, accessed
+#define SEG_CODE_EX        0x08 // Execute-Only
+#define SEG_CODE_EXA       0x09 // Execute-Only, accessed
+#define SEG_CODE_EXRD      0x0A // Execute/Read
+#define SEG_CODE_EXRDA     0x0B // Execute/Read, accessed
+#define SEG_CODE_EXC       0x0C // Execute-Only, conforming
+#define SEG_CODE_EXCA      0x0D // Execute-Only, conforming, accessed
+#define SEG_CODE_EXRDC     0x0E // Execute/Read, conforming
+#define SEG_CODE_EXRDCA    0x0F // Execute/Read, conforming, accessed
+ 
+#define GDT_CODE_PL0 SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                     SEG_LONG(0)     | SEG_SIZE(1) | SEG_GRAN(1) | \
+                     SEG_PRIV(0)     | SEG_CODE_EXRD
+ 
+#define GDT_DATA_PL0 SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                     SEG_LONG(0)     | SEG_SIZE(1) | SEG_GRAN(1) | \
+                     SEG_PRIV(0)     | SEG_DATA_RDWR
+ 
+#define GDT_CODE_PL3 SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                     SEG_LONG(0)     | SEG_SIZE(1) | SEG_GRAN(1) | \
+                     SEG_PRIV(3)     | SEG_CODE_EXRD
+ 
+#define GDT_DATA_PL3 SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                     SEG_LONG(0)     | SEG_SIZE(1) | SEG_GRAN(1) | \
+                     SEG_PRIV(3)     | SEG_DATA_RDWR
+ 
+static void gdt_write_descriptor(gdt_entry_t* entry, uint32_t base, uint32_t limit, uint16_t flag) {
+    //write the high 32 bit word
+    //set limit bits 19:16
+    entry->high_word  =  limit       & 0x000F0000;
+    //set type, p, dpl, s, g, d/b, l and avl fields
+    entry->high_word |= (flag <<  8) & 0x00F0FF00;
+    //set base bits 23:16
+    entry->high_word |= (base >> 16) & 0x000000FF;
+    //set base bits 31:24
+    entry->high_word |=  base        & 0xFF000000;
+ 
+    //write the low 32 bit word
+    //set base bits 15:0
+    entry->low_word |= base  << 16;
+    //set limit bits 15:0
+    entry->low_word |= limit  & 0x0000FFFF;
 }
 
 void gdt_init() {
-    static gdt_entry_t gdt_entries[6]        = {0};
+    static gdt_entry_t gdt_entries[5]        = {0};
     static gdt_descriptor_t   gdt_descriptor = {0};
 
     gdt_descriptor.table_base = (uint32_t)&gdt_entries;
     gdt_descriptor.table_size = sizeof(gdt_entries) - 1;
 
-    gdt_setup_null_segment(&gdt_entries[0]);
-    gdt_setup_code_segment(&gdt_entries[1]);
-    /*
-    gdt_setup_data_segment(&gdt_entries[2]);
-    gdt_setup_user_code_segment(&gdt_entries[3]);
-    gdt_setup_user_data_segment(&gdt_entries[4]);
-    */
+    gdt_write_descriptor(&gdt_entries[0], 0, 0, 0);
+    gdt_write_descriptor(&gdt_entries[1], 0x00000000, 0x000FFFFF, (GDT_CODE_PL0));
+    gdt_write_descriptor(&gdt_entries[2], 0x00000000, 0x000FFFFF, (GDT_DATA_PL0));
+    gdt_write_descriptor(&gdt_entries[3], 0x00000000, 0x000FFFFF, (GDT_CODE_PL3));
+    gdt_write_descriptor(&gdt_entries[4], 0x00000000, 0x000FFFFF, (GDT_DATA_PL3));
 
-    //gdt_activate((uint32_t)&gdt_descriptor);
+    gdt_activate((uint32_t)&gdt_descriptor);
 }
 

--- a/src/kernel/gdt/gdt.h
+++ b/src/kernel/gdt/gdt.h
@@ -1,0 +1,78 @@
+#ifndef GDT_H
+#define GDT_H
+
+#include <stdint.h>
+
+//access flag byte of a GDT segment
+struct gdt_segment_access_flag {
+    //bit for CPU to use, it gets set to 1 when the segment has been accessed. Should be set to 0
+    uint8_t accessed : 1; 
+    //if this is a code segment, this flag specifies whether the segment is readable
+    //if it's any other segment, the segment is readable and this flag states whether it's writable
+    uint8_t rw_permission : 1;
+    //if this bit is unset, the base is the lowest address and the limit is the highest (i.e. segment goes from bottom to top)
+    //if this bit is set, the base is the highest address and the limit is the lowest (i.e. segment goes from top to bottom)
+    uint8_t direction : 1;
+    //set is this is the code segment (CS)
+    //unset if this is any other segment (DS, SS, ES, FS, GS)
+    uint8_t is_code_segment : 1;
+    uint8_t always_1 : 1;
+    //0-3. specifies ring level for the segment (ring0, ring1, ring2, ring3);
+    uint8_t ring_level : 2;
+    //always 1 for valid selectors
+    uint8_t present_bit : 1;
+} __attribute__((packed));
+typedef struct gdt_segment_access_flag gdt_segment_access_flag_t;
+
+//granularity flag byte of a GDT segment
+struct gdt_segment_granularity_flag {
+    //these should just be set to 0
+    uint8_t always_0_a : 1;
+    uint8_t always_0_b : 1;
+    //0 if segment is 16-bit, 1 if segment is 32-bits
+    uint8_t segment_size : 1;
+    //0 == the segment size (limit - base) should be interpreted as a byte count
+    //1 == the segment size (limit - base) should be interpreted as a 4kb-frame count
+    uint8_t segment_length : 1;
+} __attribute__((packed));
+typedef struct gdt_segment_granularity_flag gdt_segment_granularity_flag_t;
+
+//structure contains value of one GDT entry
+//use attribute 'packed' to tell GCC not to change
+//any of the alignment in the structure
+//this structure has a carefully defined format which we must preserve
+//see here for format: http://wiki.osdev.org/Global_Descriptor_Table
+struct gdt_entry {
+    //lower 16 bits of the limit of the segment
+    //there is another 4 bits used in this value later in the structure
+    uint16_t limit_low;
+
+    //similarly, the lower 16 bits of the address where this segment begins
+    //all our segments will start at 0x0
+    uint16_t base_low;
+    //next 8 bits of base address
+    uint8_t base_mid;
+
+    //access flag byte, determining the ring this segment belongs to
+    gdt_segment_access_flag_t access_flags;
+
+    //high 4 bits of limit of segment
+    uint8_t limit_high : 4;
+
+    //granularity flags specifying how we are addressing the memory in the segment
+    gdt_segment_granularity_flag_t granularity_flags;
+
+    //last 8 bits of base address
+    uint8_t base_high;
+} __attribute__((packed));
+typedef struct gdt_entry gdt_entry_t;
+
+struct gdt_descriptor {
+    uint16_t table_size;
+    uint32_t table_base;
+} __attribute__((packed));
+typedef struct gdt_descriptor gdt_descriptor_t;
+
+void gdt_init(void);
+
+#endif

--- a/src/kernel/gdt/gdt.h
+++ b/src/kernel/gdt/gdt.h
@@ -3,20 +3,6 @@
 
 #include <stdint.h>
 
-//this structure has a carefully defined format which we must preserve
-//see here for format: http://wiki.osdev.org/Global_Descriptor_Table
-struct gdt_entry {
-    uint32_t low_word;
-    uint32_t high_word;
-} __attribute__((packed));
-typedef struct gdt_entry gdt_entry_t;
-
-struct gdt_descriptor {
-    uint16_t table_size;
-    uint32_t table_base;
-} __attribute__((packed));
-typedef struct gdt_descriptor gdt_descriptor_t;
-
 void gdt_init(void);
 
 #endif

--- a/src/kernel/gdt/gdt.h
+++ b/src/kernel/gdt/gdt.h
@@ -3,67 +3,11 @@
 
 #include <stdint.h>
 
-//access flag byte of a GDT segment
-struct gdt_segment_access_flag {
-    //bit for CPU to use, it gets set to 1 when the segment has been accessed. Should be set to 0
-    uint8_t accessed : 1; 
-    //if this is a code segment, this flag specifies whether the segment is readable
-    //if it's any other segment, the segment is readable and this flag states whether it's writable
-    uint8_t rw_permission : 1;
-    //if this bit is unset, the base is the lowest address and the limit is the highest (i.e. segment goes from bottom to top)
-    //if this bit is set, the base is the highest address and the limit is the lowest (i.e. segment goes from top to bottom)
-    uint8_t direction : 1;
-    //set is this is the code segment (CS)
-    //unset if this is any other segment (DS, SS, ES, FS, GS)
-    uint8_t is_code_segment : 1;
-    uint8_t always_1 : 1;
-    //0-3. specifies ring level for the segment (ring0, ring1, ring2, ring3);
-    uint8_t ring_level : 2;
-    //always 1 for valid selectors
-    uint8_t present_bit : 1;
-} __attribute__((packed));
-typedef struct gdt_segment_access_flag gdt_segment_access_flag_t;
-
-//granularity flag byte of a GDT segment
-struct gdt_segment_granularity_flag {
-    //these should just be set to 0
-    uint8_t always_0_a : 1;
-    uint8_t always_0_b : 1;
-    //0 if segment is 16-bit, 1 if segment is 32-bits
-    uint8_t segment_size : 1;
-    //0 == the segment size (limit - base) should be interpreted as a byte count
-    //1 == the segment size (limit - base) should be interpreted as a 4kb-frame count
-    uint8_t segment_length : 1;
-} __attribute__((packed));
-typedef struct gdt_segment_granularity_flag gdt_segment_granularity_flag_t;
-
-//structure contains value of one GDT entry
-//use attribute 'packed' to tell GCC not to change
-//any of the alignment in the structure
 //this structure has a carefully defined format which we must preserve
 //see here for format: http://wiki.osdev.org/Global_Descriptor_Table
 struct gdt_entry {
-    //lower 16 bits of the limit of the segment
-    //there is another 4 bits used in this value later in the structure
-    uint16_t limit_low;
-
-    //similarly, the lower 16 bits of the address where this segment begins
-    //all our segments will start at 0x0
-    uint16_t base_low;
-    //next 8 bits of base address
-    uint8_t base_mid;
-
-    //access flag byte, determining the ring this segment belongs to
-    gdt_segment_access_flag_t access_flags;
-
-    //high 4 bits of limit of segment
-    uint8_t limit_high : 4;
-
-    //granularity flags specifying how we are addressing the memory in the segment
-    gdt_segment_granularity_flag_t granularity_flags;
-
-    //last 8 bits of base address
-    uint8_t base_high;
+    uint32_t low_word;
+    uint32_t high_word;
 } __attribute__((packed));
 typedef struct gdt_entry gdt_entry_t;
 

--- a/src/kernel/gdt/gdt_activate.s
+++ b/src/kernel/gdt/gdt_activate.s
@@ -1,0 +1,24 @@
+; export this symbol to C code
+[global gdt_activate]
+gdt_activate:
+    ; GDT descriptor pointer is passed in eax
+    ; read it from stack
+    mov eax, [esp+4]
+    ; tell the CPU to load it!
+    lgdt [eax]
+
+    ; gdt->0x10 is where the kernel data segment is located
+    ; load it into all the data segment selectors
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+
+    ; set CS by jumping to some address where we specify the segment
+    ; the offset of the CS segment within the GDT is 0x08
+    ; far jump to address in CS!
+    jmp 0x08:.flush
+.flush:
+    ret

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -13,6 +13,7 @@
 #include <kernel/boot.h>
 #include <kernel/assert.h>
 #include <kernel/boot_info.h>
+#include <kernel/gdt/gdt.h>
 
 #define SPIN while (1) {sys_yield(RUNNABLE);}
 #define SPIN_NOMULTI do {} while (1);
@@ -35,4 +36,5 @@ void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
 
 	pmm_init();
 	pmm_dump();
+	gdt_init();
 }

--- a/src/kernel/util/paging/descriptor_tables.c
+++ b/src/kernel/util/paging/descriptor_tables.c
@@ -1,6 +1,7 @@
 #include "descriptor_tables.h"
 #include <kernel/util/interrupts/isr.h>
 #include <std/std.h>
+#include <kernel/assert.h>
 
 //access ASM functions from C
 extern void gdt_flush(uint32_t);
@@ -9,37 +10,27 @@ extern void tss_flush();
 
 //internal function prototypes
 static void init_gdt();
-static void gdt_set_gate(int32_t, uint32_t, uint32_t, uint8_t, uint8_t);
 static void init_idt();
 static void write_tss(int32_t, uint16_t, uint32_t);
 
-gdt_entry_t gdt_entries[5];
-gdt_ptr_t   gdt_ptr;
 idt_entry_t idt_entries[256];
 idt_ptr_t   idt_ptr;
 tss_entry_t tss_entry;
 
 extern isr_t interrupt_handlers[];
 
+static void gdt_install(void) {
+	NotImplemented();
+}
+
+static void gdt_set_gate(int32_t a, uint32_t b, uint32_t c, uint8_t d, uint8_t e) {
+	NotImplemented();
+}
+
 void descriptor_tables_install() {
 	printf_info("Setting up descriptor tables");
 	gdt_install();
 	idt_install();
-}
-
-void gdt_install() {
-	gdt_ptr.limit = (sizeof(gdt_entry_t) * 6) - 1;
-	gdt_ptr.base = (uint32_t)&gdt_entries;
-
-	gdt_set_gate(0, 0, 0, 0, 0); 			//null segment
-	gdt_set_gate(1, 0, 0xFFFFFFFF, 0x9A, 0xCF);	//code segment
-	gdt_set_gate(2, 0, 0xFFFFFFFF, 0x92, 0xCF); 	//data segment
-	gdt_set_gate(3, 0, 0xFFFFFFFF, 0xFA, 0xCF); 	//user mode code segment
-	gdt_set_gate(4, 0, 0xFFFFFFFF, 0xF2, 0xCF);	//user mode data segment
-	write_tss(5, 0x10, 0x0);
-
-	gdt_flush((uint32_t)&gdt_ptr);
-	tss_flush();
 }
 
 void idt_install() {
@@ -131,19 +122,6 @@ void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags) {
 	//we must uncomment the OR below when we get to user mode
 	//it sets the interrupt gate's privilege level to 3
 	idt_entries[num].flags		= flags | 0x60;
-}
-
-//sets value of one GDT entry
-static void gdt_set_gate(int32_t num, uint32_t base, uint32_t limit, uint8_t access, uint8_t gran) {
-	gdt_entries[num].base_low 	= (base & 0xFFFF);
-	gdt_entries[num].base_middle 	= (base >> 16) & 0xFF;
-	gdt_entries[num].base_high 	= (base >> 24) & 0xFF;
-
-	gdt_entries[num].limit_low	= (limit & 0xFFFF);
-	gdt_entries[num].granularity	= (limit >> 16) & 0x0F;
-
-	gdt_entries[num].granularity 	|= gran & 0xF0;
-	gdt_entries[num].access 	= access;
 }
 
 #pragma GCC diagnostic push

--- a/src/kernel/util/paging/descriptor_tables.h
+++ b/src/kernel/util/paging/descriptor_tables.h
@@ -3,28 +3,8 @@
 //allows kernel stack in TSS to be changed
 void set_kernel_stack(uint32_t stack);
 
-//structure contains value of one GDT entry
-//use attribute 'packed' to tell GCC not to change
-//any of the alignment in the structure
-struct gdt_entry_struct {
-	uint16_t limit_low;	//lower 16 bits of limit
-	uint16_t base_low;	//lower 16 bits of base
-	uint8_t base_middle;	//next 8 bits of the base
-	uint8_t access;		//access flags, determining ring for this segment to be used in
-	uint8_t granularity;
-	uint8_t base_high;	//last 8 bits of base
-} __attribute__((packed));
-typedef struct gdt_entry_struct gdt_entry_t;
-
-struct gdt_ptr_struct {
-	uint16_t limit;		//upper 16 bits of all selector limits
-	uint32_t base;		//address of the first gdt_entry_t struct
-} __attribute__((packed));
-typedef struct gdt_ptr_struct gdt_ptr_t;
-
 //publicly accessible initialization function
 void descriptor_tables_install();
-void gdt_install();
 void idt_install();
 
 //struct describing interrupt gate

--- a/src/kernel/util/paging/gdt.s
+++ b/src/kernel/util/paging/gdt.s
@@ -1,18 +1,3 @@
-[GLOBAL gdt_flush] 	; allow this to be called from C
-gdt_flush:
-	mov eax, [esp+4]	; get pointer to GDT, passed as parameter
-	lgdt [eax]		; load new GDT pointer
-
-	mov ax, 0x10		; 0x10 is offset in the GDT to data segment
-	mov ds, ax		; load all data segment selectors
-	mov es, ax
-	mov fs, ax
-	mov gs, ax
-	mov ss, ax
-	jmp 0x08:.flush		; 0x08 is the offset to our code segment: far jump!
-.flush:
-	ret
-
 [GLOBAL idt_flush] 	; allow this to be called from C
 idt_flush:
 	mov eax, [esp+4] 	; get the pointer to the IDT, passed as a parameter


### PR DESCRIPTION
New implementation resides in `kernel/gdt/` instead of shared in `kernel/paging/descriptor_tables`. Uses defines + macros from http://wiki.osdev.org/GDT_Tutorial