### PR TITLE
Fixup tasking

### DIFF
--- a/src/gfx/lib/ca_layer.c
+++ b/src/gfx/lib/ca_layer.c
@@ -119,19 +119,15 @@ void blit_layer_filled(ca_layer* dest, ca_layer* src, Rect dest_frame, Rect src_
 
 		//figure out how many px we can actually transfer over,
 		//in case src_frame exceeds dest
-		int transferabble_px = src_frame.size.width * gfx_bpp();
-		int overhang = (uint32_t)dest_row_start + (uint32_t)row_start + transferabble_px - rect_max_x(dest_frame);
-		//shrink line if necessary
-		if (overhang > 0) {
-			transferabble_px -= overhang;
-		}
-
 		int offset = (uint32_t)dest_row_start - (uint32_t)dest->raw;
 		int total_px_in_layer = (uint32_t)(dest->size.width * dest->size.height * gfx_bpp());
 		if (offset >= total_px_in_layer) {
 			break;
 		}
 
+		// blit_layer should handle bounding the provided frames so we never write to memory outside the layers,
+		// regardless of the frames passed.
+		int transferabble_px = src_frame.size.width * gfx_bpp();
 		memcpy(dest_row_start, row_start, transferabble_px);
 
 		dest_row_start += (dest->size.width * gfx_bpp());
@@ -151,7 +147,7 @@ void blit_layer(ca_layer* dest, ca_layer* src, Rect dest_frame, Rect src_frame) 
 	src_frame.size.width = MIN(src_frame.size.width, src->size.width);
 	src_frame.size.height = MIN(src_frame.size.height, src->size.height);
 
-	//clip src_frame within src
+	//clip src_frame within dest
 	if (src_frame.size.width + rect_min_x(dest_frame) >= dest->size.width) {
 		int overhang = src_frame.size.width + rect_min_x(dest_frame) - dest->size.width;
 		src_frame.size.width -= overhang;

--- a/src/gfx/lib/ca_layer.h
+++ b/src/gfx/lib/ca_layer.h
@@ -10,10 +10,10 @@
 __BEGIN_DECLS
 
 typedef struct ca_layer_t {
-       	Size size; //width/height in pixels
-       	uint8_t* raw; //raw RGB values backing this layer
-		float alpha; //transparency value bounded to continuous range [0..1]
-		List* clip_rects; //list of visible rects within layer that should be rendered
+	Size size; //width/height in pixels
+	uint8_t* raw; //raw RGB values backing this layer
+	float alpha; //transparency value bounded to continuous range [0..1]
+	List* clip_rects; //list of visible rects within layer that should be rendered
 } ca_layer;
 
 typedef struct clip_context {

--- a/src/gfx/lib/gfx.c
+++ b/src/gfx/lib/gfx.c
@@ -60,22 +60,24 @@ Vec2d vec2d(double x, float y) {
 }
 
 Screen* screen_create(Size dimensions, uint32_t* physbase, uint8_t depth) {
-            Screen* screen = kmalloc(sizeof(Screen));
+    Screen* screen = kmalloc(sizeof(Screen));
 
-            //linear frame buffer (LFB) address
-            screen->physbase = physbase;
-            screen->window = create_window_int(rect_make(point_make(0, 0), dimensions), true);
-            screen->window->superview = NULL;
-            screen->depth = depth;
-            //8 bits in a byte
-            screen->bpp = depth / 8;
-            screen->vmem = create_layer(dimensions);
+    //linear frame buffer (LFB) address
+    screen->physbase = physbase;
+    printk("create window int\n");
+    screen->window = create_window_int(rect_make(point_make(0, 0), dimensions), true);
+    printk("create window int returned\n");
+    screen->window->superview = NULL;
+    screen->depth = depth;
+    //8 bits in a byte
+    screen->bpp = depth / 8;
+    screen->vmem = create_layer(dimensions);
 
-            screen->surfaces = array_m_create(128);
-            printk_info("screen surfaces %x\n", screen->surfaces);
-            printk_info("screen surfaces size %x\n", screen->surfaces->size);
+    screen->surfaces = array_m_create(128);
+    printk_info("screen surfaces %x\n", screen->surfaces);
+    printk_info("screen surfaces size %x\n", screen->surfaces->size);
 
-            return screen;
+    return screen;
 }
 
 void gfx_teardown(Screen* screen) {

--- a/src/gfx/lib/gfx.c
+++ b/src/gfx/lib/gfx.c
@@ -72,6 +72,7 @@ Screen* screen_create(Size dimensions, uint32_t* physbase, uint8_t depth) {
     //8 bits in a byte
     screen->bpp = depth / 8;
     screen->vmem = create_layer(dimensions);
+    screen->resolution = dimensions;
 
     screen->surfaces = array_m_create(128);
     printk_info("screen surfaces %x\n", screen->surfaces);

--- a/src/gfx/lib/gfx.c
+++ b/src/gfx/lib/gfx.c
@@ -7,13 +7,16 @@
 #include <std/std.h>
 #include <std/kheap.h>
 #include <tests/gfx_test.h>
-#include <kernel/drivers/vga/vga.h>
-#include <kernel/drivers/vesa/vesa.h>
 #include "color.h"
-#include <kernel/drivers/vbe/vbe.h>
 #include <kernel/multiboot.h>
 #include <std/math.h>
 #include "bmp.h"
+
+#include <kernel/drivers/vga/vga.h>
+#include <kernel/drivers/vesa/vesa.h>
+#include <kernel/drivers/vbe/vbe.h>
+#include <kernel/drivers/mouse/mouse.h>
+#include <kernel/vmm/vmm.h>
 
 //private Window function to create root window
 Window* create_window_int(Rect frame, bool root);
@@ -64,9 +67,7 @@ Screen* screen_create(Size dimensions, uint32_t* physbase, uint8_t depth) {
 
     //linear frame buffer (LFB) address
     screen->physbase = physbase;
-    printk("create window int\n");
     screen->window = create_window_int(rect_make(point_make(0, 0), dimensions), true);
-    printk("create window int returned\n");
     screen->window->superview = NULL;
     screen->depth = depth;
     //8 bits in a byte
@@ -75,8 +76,8 @@ Screen* screen_create(Size dimensions, uint32_t* physbase, uint8_t depth) {
     screen->resolution = dimensions;
 
     screen->surfaces = array_m_create(128);
-    printk_info("screen surfaces %x\n", screen->surfaces);
-    printk_info("screen surfaces size %x\n", screen->surfaces->size);
+    printk_info("screen surfaces 0x%x", screen->surfaces);
+    printk_info("screen surfaces size 0x%x", screen->surfaces->size);
 
     return screen;
 }
@@ -107,7 +108,6 @@ void fill_screen(Screen* screen, Color color) {
     if (screen->vmem) {
         write_screen(screen);
     }
-    reset_cursor_pos();
 }
 
 void write_screen(Screen* screen) {

--- a/src/gfx/lib/gfx.c
+++ b/src/gfx/lib/gfx.c
@@ -1,22 +1,24 @@
-#include "gfx.h"
 #include <std/std.h>
-#include <kernel/kernel.h>
-#include <std/timer.h>
-#include <gfx/font/font.h>
-#include "shapes.h"
-#include <std/std.h>
-#include <std/kheap.h>
-#include <tests/gfx_test.h>
-#include "color.h"
-#include <kernel/multiboot.h>
 #include <std/math.h>
-#include "bmp.h"
+#include <std/timer.h>
+#include <std/kheap.h>
 
-#include <kernel/drivers/vga/vga.h>
-#include <kernel/drivers/vesa/vesa.h>
-#include <kernel/drivers/vbe/vbe.h>
-#include <kernel/drivers/mouse/mouse.h>
+#include <kernel/kernel.h>
 #include <kernel/vmm/vmm.h>
+#include <kernel/multiboot.h>
+#include <kernel/drivers/vga/vga.h>
+#include <kernel/drivers/vbe/vbe.h>
+#include <kernel/drivers/vesa/vesa.h>
+#include <kernel/drivers/mouse/mouse.h>
+
+#include <gfx/font/font.h>
+#include <tests/gfx_test.h>
+
+#include "gfx.h"
+#include "bmp.h"
+#include "color.h"
+#include "shapes.h"
+
 
 //private Window function to create root window
 Window* create_window_int(Rect frame, bool root);

--- a/src/gfx/lib/window.c
+++ b/src/gfx/lib/window.c
@@ -91,7 +91,6 @@ Window* create_window_int(Rect frame, bool root) {
 	window->subviews = array_m_create(MAX_ELEMENTS);
 	window->title = "Window";
 	window->animations = array_m_create(16);
-	window->superview = NULL;
 
 	//root window doesn't have a title view
 	if (!root) {
@@ -206,8 +205,6 @@ bool draw_window(Window* window) {
 		return true;
 	}
 
-		//blit_layer(window->layer, window->content_view->layer, rect_make(window->content_view->frame.origin, window->layer->size), rect_make(point_zero(), window->content_view->frame.size));
-		//return;
 	//if window is invisible, don't bother drawing
 	if (!window->layer->alpha) return false;
 

--- a/src/gfx/lib/window.c
+++ b/src/gfx/lib/window.c
@@ -91,6 +91,7 @@ Window* create_window_int(Rect frame, bool root) {
 	window->subviews = array_m_create(MAX_ELEMENTS);
 	window->title = "Window";
 	window->animations = array_m_create(16);
+	window->superview = NULL;
 
 	//root window doesn't have a title view
 	if (!root) {

--- a/src/kernel/drivers/mouse/mouse.c
+++ b/src/kernel/drivers/mouse/mouse.c
@@ -69,7 +69,7 @@ uint8_t mouse_events() {
 	return mouse_state;
 }
 
-static void _mouse_set_initial_cursospos() {
+void mouse_reset_cursorpos() {
 	Screen* s = gfx_screen();
 	if (s) {
 		running_x = s->resolution.width / 2;
@@ -91,10 +91,10 @@ static void _mouse_constrain_to_screen_size() {
 	running_y = MIN(running_y, dimensions.height - 5);
 }
 
-static void mouse_handle_event(int x, int y) {
+static void _mouse_handle_event(int x, int y) {
 	//set initial mouse position if necessary
 	if (running_x == -1 && running_y == -1) {
-		_mouse_set_initial_cursospos();
+		mouse_reset_cursorpos();
 	}
 
 	y = -y;
@@ -139,7 +139,7 @@ static int mouse_callback(registers_t* regs) {
 			break;
 		case 2:
 			mouse_byte[2] = inb(0x60);
-			update_mouse_position(mouse_byte[1], mouse_byte[2]);
+			_mouse_handle_event(mouse_byte[1], mouse_byte[2]);
 			mouse_cycle = 0;
 
 			//hook into task switch

--- a/src/kernel/drivers/mouse/mouse.c
+++ b/src/kernel/drivers/mouse/mouse.c
@@ -103,6 +103,7 @@ static void _mouse_handle_event(int x, int y) {
 	running_y += y;
 
 	_mouse_constrain_to_screen_size();
+	printk_dbg("mouse: (%d, %d)", running_x, running_y);
 }
 
 #pragma GCC diagnostic push

--- a/src/kernel/drivers/mouse/mouse.h
+++ b/src/kernel/drivers/mouse/mouse.h
@@ -2,6 +2,14 @@
 #define MOUSE_H
 
 #include <gfx/lib/shapes.h>
+#include <stdbool.h>
+
+// TODO(PT): use this!
+typedef struct mouse_button_state {
+    bool left_down : 1;
+    bool right_down : 1;
+    bool middle_down : 1;
+} mouse_button_state_t;
 
 //install mouse driver
 void mouse_install();

--- a/src/kernel/drivers/mouse/mouse.h
+++ b/src/kernel/drivers/mouse/mouse.h
@@ -26,4 +26,6 @@ uint8_t mouse_events();
 //blocks running task until mouse event is recieved
 void mouse_event_wait();
 
+void mouse_reset_cursorpos();
+
 #endif

--- a/src/kernel/drivers/pit/pit.c
+++ b/src/kernel/drivers/pit/pit.c
@@ -1,5 +1,4 @@
 #include "pit.h"
-#include <kernel/interrupts/interrupts.h>
 #include <kernel/kernel.h>
 #include <kernel/assert.h>
 #include <std/math.h>
@@ -17,14 +16,9 @@
 
 static volatile uint32_t tick = 0;
 
-//defined in timer.c
-//inform that a tick has occured
-extern void handle_tick();
-
 static void context_switch(register_state_t* regs);
 static int tick_callback(register_state_t* regs) {
 	tick++;
-	_timer_handle_pit_tick(regs);
 	return 0;
 }
 

--- a/src/kernel/drivers/pit/pit.h
+++ b/src/kernel/drivers/pit/pit.h
@@ -8,6 +8,7 @@
 #define PIT_TICK_GRANULARITY_10MS 100
 #define PIT_TICK_GRANULARITY_20MS 50
 #define PIT_TICK_GRANULARITY_50MS 20
+#define PIT_TICK_GRANULARITY_1000MS 1
 
 void pit_timer_init(uint32_t frequency);
 uint32_t pit_clock();

--- a/src/kernel/drivers/pit/pit.h
+++ b/src/kernel/drivers/pit/pit.h
@@ -2,6 +2,9 @@
 #define PIT_H
 
 #include <std/common.h>
+#include <kernel/interrupts/interrupts.h>
+
+#define PIT_INT_VECTOR INT_VECOR_IRQ0
 
 #define PIT_TICK_GRANULARITY_1MS  1000
 #define PIT_TICK_GRANULARITY_5MS  200

--- a/src/kernel/drivers/vesa/vesa.c
+++ b/src/kernel/drivers/vesa/vesa.c
@@ -15,68 +15,69 @@ Window* create_window_int(Rect frame, bool root);
 
 //sets up VESA for mode
 Screen* switch_to_vesa(uint32_t vesa_mode, bool create) {
-		kernel_begin_critical();
+	kernel_begin_critical();
 
-		vesa_info info;
-		vbe_mode_info mode_info;
-		regs16_t regs;
+	vesa_info info;
+	vbe_mode_info mode_info;
+	regs16_t regs;
 
-		//get VESA information
+	//get VESA information
 
-		//buffer stores info before being copied into structure
-		uint32_t buffer = (uint32_t)kmalloc(sizeof(vesa_info)) & 0xFFFFF;
+	//buffer stores info before being copied into structure
+	uint32_t buffer = (uint32_t)kmalloc(sizeof(vesa_info)) & 0xFFFFF;
 
-		memcpy((void*)buffer, "VBE2", 4);
-		memset(&regs, 0, sizeof(regs));
+	memcpy((void*)buffer, "VBE2", 4);
+	memset(&regs, 0, sizeof(regs));
 
-		regs.ax = 0x4F00; //00 gets VESA information
-		regs.di = buffer & 0xF;
-		regs.es = (buffer >> 4) & 0xFFFF;
-		int32(0x10, &regs);
+	regs.ax = 0x4F00; //00 gets VESA information
+	regs.di = buffer & 0xF;
+	regs.es = (buffer >> 4) & 0xFFFF;
+	int32(0x10, &regs);
 
-		//copy info from buffer into struct
-		memcpy(&info, (void*)buffer, sizeof(vesa_info));
+	//copy info from buffer into struct
+	memcpy(&info, (void*)buffer, sizeof(vesa_info));
 
-		//get VESA mode information
+	//get VESA mode information
 
-		//buffer to store mode info before copying into structure
-		//TODO figure out why this isn't a pointer
-		//things break if we make this a pointer
-		//but it's a leak ATM
-		uint32_t mode_buffer = (uint32_t)(kmalloc(sizeof(vbe_mode_info))) & 0xFFFFF;
+	//buffer to store mode info before copying into structure
+	//TODO figure out why this isn't a pointer
+	//things break if we make this a pointer
+	//but it's a leak ATM
+	uint32_t mode_buffer = (uint32_t)(kmalloc(sizeof(vbe_mode_info))) & 0xFFFFF;
 
-		memset(&regs, 0, sizeof(regs));
-//VESA mode
-		//0x118: 1024x768x24
-		//0x112: 640x400x24
+	memset(&regs, 0, sizeof(regs));
+	//VESA mode
+	//0x118: 1024x768x24
+	//0x112: 640x400x24
 
-		regs.ax = 0x4F01; //01 gets VBE mode information
-		regs.di = mode_buffer & 0xF;
-		regs.es = (mode_buffer >> 4) & 0xFFFF;
-		regs.cx = vesa_mode; //mode to get info for
-		int32(0x10, &regs);
+	regs.ax = 0x4F01; //01 gets VBE mode information
+	regs.di = mode_buffer & 0xF;
+	regs.es = (mode_buffer >> 4) & 0xFFFF;
+	regs.cx = vesa_mode; //mode to get info for
+	int32(0x10, &regs);
 
-		//copy mode info from buffer into struct
-		memcpy(&mode_info, (uint32_t*)mode_buffer, sizeof(vbe_mode_info));
+	//copy mode info from buffer into struct
+	memcpy(&mode_info, (uint32_t*)mode_buffer, sizeof(vbe_mode_info));
 
-		regs.ax = 0x4F02; //02 sets graphics mode
+	regs.ax = 0x4F02; //02 sets graphics mode
 
-		//sets up mode with linear frame buffer instead of bank switching
-		//or 0x4000 turns on linear frame buffer
-		regs.bx = (vesa_mode | 0x4000);
-		int32(0x10, &regs);
-			
-		//screen_create depends on knowing gfx_bpp, so we must call this with NULL for the screen to create the screen,
-		//and then we can call it normally after the screen is created
-		process_gfx_switch(NULL, mode_info.bpp);
+	//sets up mode with linear frame buffer instead of bank switching
+	//or 0x4000 turns on linear frame buffer
+	regs.bx = (vesa_mode | 0x4000);
+	int32(0x10, &regs);
+		
+	//screen_create depends on knowing gfx_bpp, so we must call this with NULL for the screen to create the screen,
+	//and then we can call it normally after the screen is created
+	process_gfx_switch(NULL, mode_info.bpp);
 
-		kernel_end_critical();
+	kernel_end_critical();
 
-		if (create) {
-			Screen* screen = screen_create(size_make(mode_info.x_res, mode_info.y_res), (uint32_t*)mode_info.physbase, mode_info.bpp);
-			process_gfx_switch(screen, mode_info.bpp);
-			return screen;
-		}
+	if (create) {
+		printk("screen_create (%d, %d), physbase 0x%x, %d bpp\n", mode_info.x_res, mode_info.y_res, mode_info.physbase, mode_info.bpp);
+		Screen* screen = screen_create(size_make(mode_info.x_res, mode_info.y_res), (uint32_t*)mode_info.physbase, mode_info.bpp);
+		process_gfx_switch(screen, mode_info.bpp);
+		return screen;
+	}
 
-		return 0;
+	return 0;
 }

--- a/src/kernel/interrupts/int_notifier.c
+++ b/src/kernel/interrupts/int_notifier.c
@@ -1,0 +1,78 @@
+#include "int_notifier.h"
+
+#include <limits.h>
+#include <std/memory.h>
+#include <std/common.h>
+#include <kernel/drivers/rtc/clock.h>
+#include <kernel/syscall/sysfuncs.h>
+
+static int callback_num = 0;
+static int_notify_callback_t callback_table[MAX_CALLBACKS] = {0};
+
+static void clear_table() {
+	memset(&callback_table, 0, sizeof(timer_callback_t) * callback_num);
+	callback_num = 0;
+}
+
+static int next_open_callback_index() {
+	for (int i = 0; i < callback_num; i++) {
+		if (!callback_table[i].func) {
+			//this index doesn't have valid data, fit for reuse
+			return i;
+		}
+	}
+	//all indexes up to callback_num are in use, so return callback_num
+	return callback_num;
+}
+
+int_notify_callback_t* int_notifier_register_callback(uint32_t int_no, void* func, void* context, bool repeats) {
+	int next_open_index = next_open_callback_index();
+	//only add callback if we have room
+	if (callback_num + 1 < MAX_CALLBACKS || next_open_index < callback_num) {
+        callback_table[callback_num].int_no = int_no;
+		callback_table[callback_num].func = func;
+		callback_table[callback_num].context = context;
+		callback_table[callback_num].repeats = repeats;
+
+		callback_num++;
+
+		return &(callback_table[callback_num]);
+	}
+
+    panic("int callback table out of space");
+	//TODO expand table instead of clearing it
+	clear_table();
+	//try adding the callback again now that we know the table has room
+    return int_notifier_register_callback(int_no, func, context, repeats);
+}
+
+void int_notifier_remove_callback(int_notify_callback_t* callback) {
+	//find this callback in callback table
+	bool found = false;
+	for (int i = 0; i < callback_num; i++) {
+		if (callback_table[callback_num].func == callback->func && callback_table[callback_num].int_no == callback->int_no) {
+			found = true;
+			break;
+		}
+	}
+	if (!found) {
+		panic("tried to delete nonexistant interrupt callback. investigate!");
+	}
+	memset(callback, 0, sizeof(int_notify_callback_t));
+}
+
+void int_notifier_handle_interrupt(registers_t* register_state) {
+	//look through every callback and see if we should fire
+	for (int i = 0; i < callback_num; i++) {
+        // if this callback is waiting for the interrupt that was fired, invoke the callback
+        if (callback_table[i].int_no == register_state->int_no) {
+			void(*callback_func)(void*) = (void(*)(void*))callback_table[i].func;
+			callback_func(callback_table[i].context);
+
+			//if we only fire once, trash this callback
+			if (!callback_table[i].repeats) {
+				int_notifier_remove_callback(&(callback_table[i]));
+			}
+		}
+	}
+}

--- a/src/kernel/interrupts/int_notifier.h
+++ b/src/kernel/interrupts/int_notifier.h
@@ -1,0 +1,29 @@
+#ifndef INT_NOTIFIER_H
+#define INT_NOTIFIER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <std/std_base.h>
+#include <kernel/interrupts/interrupts.h>
+
+__BEGIN_DECLS
+
+#define MAX_CALLBACKS 128
+
+typedef struct {
+    uint32_t int_no;
+	void* func;
+	void* context;
+	bool repeats;
+} int_notify_callback_t;
+
+int_notify_callback_t* int_notifier_register_callback(uint32_t int_no, void* func, void* context, bool repeats);
+void int_notifier_remove_callback(int_notify_callback_t* callback);
+
+// Friend function for interrupt.c
+void int_notifier_handle_interrupt(registers_t* register_state);
+
+__END_DECLS
+
+#endif // INT_NOTIFIER_H

--- a/src/kernel/interrupts/int_notifier.h
+++ b/src/kernel/interrupts/int_notifier.h
@@ -18,7 +18,15 @@ typedef struct {
 	bool repeats;
 } int_notify_callback_t;
 
+/* Run the provided function when the the interrupt `int_no` is received. 
+ * Callbacks set up by this method will only be invoked after the system has finished handling the interrupt.
+ * If you provide `context`, it will be passed to the provided function on invocation.
+ * Returns a struct encapsulating the callback, which you can use to remove it.
+ */
 int_notify_callback_t* int_notifier_register_callback(uint32_t int_no, void* func, void* context, bool repeats);
+
+/* Stop invoking the provided callback.
+ */
 void int_notifier_remove_callback(int_notify_callback_t* callback);
 
 // Friend function for interrupt.c

--- a/src/kernel/interrupts/interrupts.c
+++ b/src/kernel/interrupts/interrupts.c
@@ -82,6 +82,14 @@ void irq_receive(register_state_t* regs) {
 
     pic_signal_end_of_interrupt(int_no);
 
+	extern uint32_t* _current_task_small;
+	if (int_no == 0x20 && _current_task_small != NULL) {
+		void task_switch_new();
+		void access_context();
+		access_context();
+		task_switch_new();
+	}
+
 	return ret;
 }
 

--- a/src/kernel/interrupts/interrupts.c
+++ b/src/kernel/interrupts/interrupts.c
@@ -83,7 +83,7 @@ void irq_receive(register_state_t* regs) {
 	else {
 		printf("Unhandled IRQ: %d\n", int_no);
 	}
-    pic_signal_end_of_interrupt(int_no);
+	pic_signal_end_of_interrupt(int_no);
 
 	int_notifier_handle_interrupt(regs);
 

--- a/src/kernel/interrupts/interrupts.c
+++ b/src/kernel/interrupts/interrupts.c
@@ -2,12 +2,13 @@
 #include "idt_structures.h"
 #include "idt.h"
 #include "cpu_fault_handlers.h"
+#include "int_notifier.h"
 
 #include <std/common.h>
 
 #include <kernel/kernel.h>
-#include <kernel/multitasking//tasks/task.h>
 #include <kernel/assert.h>
+#include <kernel/multitasking/tasks/task.h>
 
 static int_callback_t interrupt_handlers[256] = {0};
 
@@ -64,6 +65,9 @@ int isr_receive(register_state_t* regs) {
 	else {
 		printf("Unhandled interrupt: %d\n", int_no);
 	}
+
+	int_notifier_handle_interrupt(regs);
+
 	return ret;
 }
 
@@ -79,14 +83,9 @@ void irq_receive(register_state_t* regs) {
 	else {
 		printf("Unhandled IRQ: %d\n", int_no);
 	}
-
     pic_signal_end_of_interrupt(int_no);
 
-	extern uint32_t* _current_task_small;
-	if (int_no == 0x20 && _current_task_small != NULL) {
-		void task_switch();
-		task_switch();
-	}
+	int_notifier_handle_interrupt(regs);
 
 	return ret;
 }

--- a/src/kernel/interrupts/interrupts.c
+++ b/src/kernel/interrupts/interrupts.c
@@ -85,8 +85,6 @@ void irq_receive(register_state_t* regs) {
 	extern uint32_t* _current_task_small;
 	if (int_no == 0x20 && _current_task_small != NULL) {
 		void task_switch_new();
-		void access_context();
-		access_context();
 		task_switch_new();
 	}
 

--- a/src/kernel/interrupts/interrupts.c
+++ b/src/kernel/interrupts/interrupts.c
@@ -84,8 +84,8 @@ void irq_receive(register_state_t* regs) {
 
 	extern uint32_t* _current_task_small;
 	if (int_no == 0x20 && _current_task_small != NULL) {
-		void task_switch_new();
-		task_switch_new();
+		void task_switch();
+		task_switch();
 	}
 
 	return ret;

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -43,6 +43,7 @@ void system_mem() {
 void drivers_init(void) {
     pit_timer_init(PIT_TICK_GRANULARITY_1MS);
     serial_init();
+    mouse_install();
 }
 
 static void kernel_spinloop() {

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -69,6 +69,7 @@ void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
     drivers_init();
 
     //kernel features
+    timer_init();
     pmm_init();
     vmm_init();
     kheap_init();

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -73,8 +73,11 @@ void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
     vmm_init();
     kheap_init();
     syscall_init();
-    //testing!
-    tasking_init_small();
+    tasking_init();
+
+    while (1) {
+        printf("#");
+    }
 
     while (1) {}
     kernel_spinloop();

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -75,10 +75,6 @@ void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
     syscall_init();
     tasking_init();
 
-    while (1) {
-        printf("#");
-    }
-
     while (1) {}
     kernel_spinloop();
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -51,6 +51,14 @@ static void kernel_spinloop() {
     asm("hlt");
 }
 
+static void kernel_idle() {
+    while (1) {
+        //nothing to do!
+        //put the CPU to sleep until the next interrupt
+        asm volatile("hlt");
+    }
+}
+
 uint32_t initial_esp = 0;
 void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
     initial_esp = initial_stack;
@@ -74,8 +82,10 @@ void kernel_main(struct multiboot_info* mboot_ptr, uint32_t initial_stack) {
     vmm_init();
     kheap_init();
     syscall_init();
+    
     tasking_init();
+    kernel_idle();
 
-    while (1) {}
+    //the above call should never return, but just in case...
     kernel_spinloop();
 }

--- a/src/kernel/multitasking/tasks/process_small.s
+++ b/src/kernel/multitasking/tasks/process_small.s
@@ -1,0 +1,35 @@
+[EXTERN _current_task_small]
+[EXTERN task_small_offset_to_context]
+[GLOBAL context_switch]
+context_switch:
+    mov ecx, [esp + 0x4] ; save new task argument
+;Save the old task's state
+   ;Save registers that are supposed to be callee-saved
+   push eax
+   push ebx
+   push esi
+   push edi
+   push ebp
+
+; 0x6c is the offset to _current_task_small->context! FIX ME PT
+   mov esi,[_current_task_small]  ;Get address of old task's "thread control block" from global variable
+   mov [esi+0x6c],esp   ;Save old task' ESP in its "thread control block"
+
+;Load the new task's state
+
+   mov edi,ecx         ;Get address of new task's "thread control block" from arg
+   mov [_current_task_small], edi  ;Set address of new task's "thread control block" in global variable for later
+   mov esp,[edi+0x6c]   ;Load new ESP from new task's "thread control block"
+
+   ;Restore registers that were callee-saved
+
+   pop ebp
+   pop edi
+   pop esi
+   pop ebx
+   pop eax
+
+   ;Return to the new task's EIP (that was stored on its stack
+
+   sti
+   ret

--- a/src/kernel/multitasking/tasks/process_small.s
+++ b/src/kernel/multitasking/tasks/process_small.s
@@ -1,35 +1,41 @@
 [EXTERN _current_task_small]
-[EXTERN task_small_offset_to_context]
+[EXTERN _task_context_offset]
+
 [GLOBAL context_switch]
 context_switch:
-    mov ecx, [esp + 0x4] ; save new task argument
-;Save the old task's state
-   ;Save registers that are supposed to be callee-saved
-   push eax
-   push ebx
-   push esi
-   push edi
-   push ebp
+    ; Save arg to function containing task to switch to in ecx
+    mov ecx, [esp + 0x4]
 
-; 0x6c is the offset to _current_task_small->context! FIX ME PT
-   mov esi,[_current_task_small]  ;Get address of old task's "thread control block" from global variable
-   mov [esi+0x6c],esp   ;Save old task' ESP in its "thread control block"
+;Save the old task's state
+    ; Save registers that are supposed to be callee-saved
+    push eax
+    push ebx
+    push esi
+    push edi
+    push ebp
+
+    ; Save preempted task's esp as _current_task->machine_state
+    mov eax, [_current_task_small]
+    mov ebx, [_task_context_offset]
+    add eax, ebx
+    mov [eax], esp
 
 ;Load the new task's state
+    ; Set the provided argument to _current_task_small
+    mov [_current_task_small], ecx
 
-   mov edi,ecx         ;Get address of new task's "thread control block" from arg
-   mov [_current_task_small], edi  ;Set address of new task's "thread control block" in global variable for later
-   mov esp,[edi+0x6c]   ;Load new ESP from new task's "thread control block"
+    ; Load esp with _current_task->machine_state
+    mov ebx, [_task_context_offset]
+    add ecx, ebx
+    mov esp,[ecx]
 
-   ;Restore registers that were callee-saved
+    ; Restore registers that were callee-saved
+    pop ebp
+    pop edi
+    pop esi
+    pop ebx
+    pop eax
 
-   pop ebp
-   pop edi
-   pop esi
-   pop ebx
-   pop eax
-
-   ;Return to the new task's EIP (that was stored on its stack
-
-   sti
-   ret
+    ; Return to the new task's EIP (that was stored on its stack
+    sti
+    ret

--- a/src/kernel/multitasking/tasks/task.c
+++ b/src/kernel/multitasking/tasks/task.c
@@ -660,7 +660,7 @@ task_t* first_responder() {
     return first_responder_task;
 }
 
-int fork(char* name) {
+int fork_old(char* name) {
     Deprecated();
     if (!tasking_is_active()) {
         panic("called fork() before tasking was active");
@@ -735,7 +735,7 @@ int fork(char* name) {
 task_small_t* first_queue_runnable(array_m* queue, int offset) {
     for (int i = offset; i < queue->size; i++) {
         task_small_t* tmp = array_m_lookup(queue, i);
-        if (tmp->waiting_state == RUNNABLE) {
+        if (tmp->blocked_info.status == RUNNABLE) {
             return tmp;
         }
     }
@@ -751,7 +751,7 @@ array_m* first_queue_containing_runnable(void) {
 
     //TODO figure out why this block doesn't work
     while (curr) {
-        if (curr->waiting_state == RUNNABLE) {
+        if (curr->blocked_info.status == RUNNABLE) {
             //if this task has a higher priority (lower queue #), or this is the first runnable task we've found,
             //mark it as best
             if (!highest_prio_runnable || curr->queue < highest_prio_runnable->queue) {
@@ -762,7 +762,7 @@ array_m* first_queue_containing_runnable(void) {
     }
 
     array_m* queue = array_m_lookup(queues, highest_prio_runnable->queue);
-    if (!highest_prio_runnable || highest_prio_runnable->waiting_state != RUNNABLE || !queue->size) {
+    if (!highest_prio_runnable || highest_prio_runnable->blocked_info.status != RUNNABLE || !queue->size) {
         //if (1) {
         //printf_err("Couldn't find runnable task in linked list of tasks!");
         for (int i = 0; i < queues->size; i++) {
@@ -810,7 +810,7 @@ task_small_t* mlfq_schedule() {
         //attempt to save time by first looking at the next task in linked list
         task_small_t* next = current_task->next;
         if (!next) next = active_list;
-        while (next->waiting_state != RUNNABLE) {
+        while (next->blocked_info.status != RUNNABLE) {
             next = next->next;
             if (!next) {
                 next = active_list;
@@ -1008,7 +1008,7 @@ void proc() {
             }
             printk(" %d/%d ms ", task->lifespan, runtime);
 
-            switch (task->waiting_state) {
+            switch (task->blocked_info.status) {
                 case RUNNABLE:
                 printk("(runnable)");
                 break;
@@ -1016,7 +1016,7 @@ void proc() {
                 printk("(blocked by keyboard)");
                 break;
                 case PIT_WAIT:
-                printk("(blocked by timer, wakes %d)", task->wake_timestamp);
+                printk("(blocked by timer, wakes %d)", task->blocked_info.wake_timestamp);
                 break;
                 case MOUSE_WAIT:
                 printk("(blocked by mouse)");

--- a/src/kernel/multitasking/tasks/task.c
+++ b/src/kernel/multitasking/tasks/task.c
@@ -491,7 +491,7 @@ static void _create_task_queues(mlfq_option options) {
     }
 }
 
-void tasking_init(mlfq_option options) {
+void tasking_init_old(mlfq_option options) {
     Deprecated();
     if (tasking_is_active()) {
         panic("called tasking_init() after it was already active");

--- a/src/kernel/multitasking/tasks/task.c
+++ b/src/kernel/multitasking/tasks/task.c
@@ -530,7 +530,7 @@ void tasking_init_old(mlfq_option options) {
 
     //create callback to switch tasks
     void handle_pit_tick();
-    add_callback((void*)handle_pit_tick, 4, true, 0);
+    timer_callback_register((void*)handle_pit_tick, 4, true, 0);
 
     printf_dbg("forking system processes");
     //idle task

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -8,8 +8,8 @@
 
 static int next_pid = 1;
 
-const int task_small_offset_to_context = offsetof(struct task_small, context);
 task_small_t* _current_task_small = 0;
+const uint32_t _task_context_offset = offsetof(struct task_small, machine_state);
 static task_small_t* _task_list_head = 0;
 static timer_callback_t* pit_callback = 0;
 
@@ -90,7 +90,7 @@ task_small_t* task_construct(uint32_t entry_point) {
     *(stack_top--) = 0;                //edi
     *(stack_top)   = 0;                //ebp
 
-    new_task->context = (struct context*)stack_top;
+    new_task->machine_state = (task_context_t*)stack_top;
 
     _tasking_add_task_to_runlist(new_task);
 }
@@ -149,9 +149,12 @@ void tasking_init() {
     //task_small_t* buddy1 = task_construct((uint32_t)&new_my_task3);
 
     printf_info("Multitasking initialized");
+    //printf("offset: 0x%x\n", task_small_offset_to_context);
     kernel_end_critical();
 }
 
-void access_context(struct task_small t) {
-    t.context = 1;
+void access_context(task_small_t* t) {
+    t->machine_state = 1;
+    struct task_small x= *t;
+    x.machine_state = 7;
 }

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -117,6 +117,7 @@ task_small_t* thread_spawn(void* entry_point) {
 
     uint32_t stack_size = 0x1000;
     char *stack = kmalloc(stack_size);
+    memset(stack, 0, stack_size);
 
     uint32_t *stack_top = (uint32_t *)(stack + stack_size - 0x4); // point to top of malloc'd stack
     *(stack_top--) = entry_point;   //address of task's entry point

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -129,14 +129,18 @@ void tasking_init_small() {
 
     printf_info("Multitasking init...");
     mutex = lock_create();
-    pit_callback = add_callback((void*)scheduler_tick, 10, true, 0);
+    //pit_callback = add_callback((void*)scheduler_tick, 5, true, 0);
 
     //init first task (kernel task)
     _current_task_small = task_construct((uint32_t)&new_task_entry);
     _task_list_head = _current_task_small;
     //init another
     task_small_t* buddy = task_construct((uint32_t)&new_my_task2);
+    //task_small_t* buddy1 = task_construct((uint32_t)&new_my_task3);
 
-    printf_info("Tasking initialized with kernel PID %d", getpid());
     kernel_end_critical();
+}
+
+void access_context(struct task_small t) {
+    t.context = 1;
 }

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -3,7 +3,7 @@
 #include <std/timer.h>
 #include <kernel/segmentation/gdt_structures.h>
 
-#define TASK_QUANTUM 20
+#define TASK_QUANTUM 10
 #define MAX_TASKS 64
 
 static int next_pid = 1;
@@ -28,6 +28,12 @@ void task_sleepy() {
     sleep(2000);
     printf("slept!\n");
     while (1) {}
+}
+
+void sleep(uint32_t ms) {
+    _current_task_small->blocked_info.status = PIT_WAIT;
+    _current_task_small->blocked_info.wake_timestamp = time() + ms;
+    task_switch();
 }
 
 static task_small_t* _tasking_get_next_task(task_small_t* previous_task) {

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -1,6 +1,7 @@
 #include "task_small.h"
 
 #include <std/timer.h>
+#include <kernel/multitasking/std_stream.h>
 #include <kernel/segmentation/gdt_structures.h>
 
 #define TASK_QUANTUM 10
@@ -80,6 +81,25 @@ static void _tasking_add_task_to_runlist(task_small_t* task) {
     }
     task_small_t* list_tail = _tasking_last_task_in_runlist();
     list_tail->next = task;
+}
+
+task_small_t* tasking_get_task_with_pid(int pid) {
+    if (!_current_task_small) {
+        return NULL;
+    }
+    task_small_t* iter = _current_task_small;
+    for (int i = 0; i < MAX_TASKS; i++) {
+        if ((iter)->id == pid) {
+            return iter;
+        }
+        iter = (iter)->next;
+    }
+    //not found
+    return NULL;
+}
+
+task_small_t* tasking_get_current_task() {
+    return tasking_get_task_with_pid(getpid());
 }
 
 task_small_t* thread_spawn_with_machine_state(task_context_t* state) {

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -100,8 +100,17 @@ task_small_t* task_construct(uint32_t entry_point) {
     new_task->context = (struct context*)stack_top;
 
     _tasking_add_task_to_runlist(new_task);
+}
 
-    return new_task;
+void task_switch_new() {
+    void context_switch(uint32_t* new_task);
+
+    task_small_t* previous_task = _current_task_small;
+    task_small_t* next_task = _tasking_get_next_task(previous_task);
+
+    //will update _current_task_small
+    printf("S");
+    context_switch(next_task);
 }
 
 int getpid() {

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -135,13 +135,13 @@ task_small_t* thread_spawn(void* entry_point) {
 }
 
 task_small_t* task_spawn(void* entry_point) {
-    // a task is simply a thread with its own virtual address space
-    // the new task's address space is a clone of the task that spawned it
     task_small_t* new_task = thread_spawn;
     new_task->is_thread = false;
-    panic("clone vmm here");
-    //new_task->vmm 
-    return NULL;
+    // a task is simply a thread with its own virtual address space
+    // the new task's address space is a clone of the task that spawned it
+    new_task->vmm = vmm_clone_active_pdir();
+    return new_task;
+}
 }
 
 /*
@@ -153,6 +153,9 @@ void tasking_goto_task(task_small_t* new_task) {
     new_task->current_timeslice_start_date = now;
     new_task->current_timeslice_end_date = now + TASK_QUANTUM;
 
+    if (new_task->vmm != _current_task_small->vmm) {
+        vmm_load_pdir(new_task->vmm);
+    }
     // this method will update _current_task_small
     // this method performs the actual context switch and also updates _current_task_small
     context_switch(new_task);

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -52,19 +52,6 @@ static task_small_t* _tasking_last_task_in_runlist() {
     return NULL;
 }
 
-void task_switch_now() {
-    /*
-    Immediately preempt the running task.
-    */
-    //set the process's time left to run to zero
-    //set the time to next schedule to 0
-    //task_switch_from_pit will be called on the next PIT interrupt
-    _current_task_small->current_timeslice_end_date = time();
-    timer_deliver_immediately(pit_callback);
-    //put CPU to sleep until the next interrupt
-    asm("hlt");
-}
-
 static void _tasking_add_task_to_runlist(task_small_t* task) {
     if (!_current_task_small) {
         _current_task_small = task;

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -25,21 +25,27 @@ void task_entry();
 void task2() {
     while (1) {
         printf("B");
-        task_switch_new();
+        task_switch();
     }
 }
 void task3() {
     while (1) {
         printf("C");
-        task_switch_new();
+        task_switch();
     }
 }
 
-void task_new() {
+void task_new(int i) {
     while (1) {
         printf("%d", getpid());
-        //task_switch_new();
+        sys_yield(RUNNABLE);
     }
+}
+
+void task_sleepy() {
+    sleep(2000);
+    printf("slept!\n");
+    while (1) {}
 }
 
 static task_small_t* _tasking_get_next_task(task_small_t* previous_task) {

--- a/src/kernel/multitasking/tasks/task_small.c
+++ b/src/kernel/multitasking/tasks/task_small.c
@@ -136,7 +136,7 @@ task_small_t* thread_spawn(void* entry_point) {
 }
 
 task_small_t* task_spawn(void* entry_point) {
-    task_small_t* new_task = thread_spawn;
+    task_small_t* new_task = thread_spawn(entry_point);
     new_task->is_thread = false;
     // a task is simply a thread with its own virtual address space
     // the new task's address space is a clone of the task that spawned it

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -4,35 +4,30 @@
 #include <stdint.h>
 #include <kernel/multitasking/tasks/task.h>
 
-struct context {
+typedef struct task_context {
 	uint32_t ebp;
 	uint32_t edi;
 	uint32_t esi;
 	uint32_t ebx;
 	uint32_t eax;
 	uint32_t eip;
-};
+} task_context_t;
 
 typedef struct task_small {
+	uint32_t id;  //PID
 	char* name; //user-printable process name
-	int id;  //PID
-    task_state state; // TODO(pt) change to task_wait_state?
-
-	registers_t register_state;
-
-	int queue; //scheduler ring this task is slotted in
-    uint32_t wake_timestamp; //used if process is in PIT_WAIT state
+	task_context_t* machine_state; //registers at the time of last preemption
+    task_state waiting_state; // TODO(pt) change to task_wait_state?
+	struct task_small_t* next; // next task in linked list of all tasks
 
 	uint32_t current_timeslice_start_date;
 	uint32_t current_timeslice_end_date;
 
+	uint32_t queue; //scheduler ring this task is slotted in
 	uint32_t relinquish_date;
 	uint32_t lifespan;
-	struct task_small_t* next;
 
-    bool _has_run; //has the task ever been scheduled?
-
-	struct context* context;
+    uint32_t wake_timestamp; //used if process is in PIT_WAIT state
 } task_small_t;
 
 void tasking_init_small();

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -14,11 +14,16 @@ typedef struct task_context {
 	uint32_t eip;
 } task_context_t;
 
+typedef struct task_block_state {
+	task_state status;
+	uint32_t wake_timestamp; // used if process is in PIT_WAIT
+} task_block_state_t;
+
 typedef struct task_small {
-	uint32_t id;  //PID
-	char* name; //user-printable process name
-	task_context_t* machine_state; //registers at the time of last preemption
-    task_state waiting_state; // TODO(pt) change to task_wait_state?
+	uint32_t id;  // PID
+	char* name; // user-printable process name
+	task_context_t* machine_state; // registers at the time of last preemption
+	task_block_state_t blocked_info; // runnable state
 	struct task_small_t* next; // next task in linked list of all tasks
 
 	uint32_t current_timeslice_start_date;

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <kernel/multitasking/tasks/task.h>
+#include <kernel/vmm/vmm.h>
 
 typedef struct task_context {
 	uint32_t ebp;
@@ -27,11 +28,15 @@ typedef struct task_small {
 	uint32_t lifespan;
 
     uint32_t wake_timestamp; //used if process is in PIT_WAIT state
+	bool is_thread;
 } task_small_t;
 
 void tasking_init_small();
 bool tasking_is_active();
 
 void task_switch();
+
+task_small_t* thread_spawn(void* entry_point);
+task_small_t* task_spawn(void* entry_point);
 
 #endif

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <kernel/multitasking/tasks/task.h>
 #include <kernel/vmm/vmm.h>
+#define FD_MAX 64
 
 typedef struct task_context {
 	uint32_t ebp;
@@ -44,4 +45,6 @@ void task_switch();
 task_small_t* thread_spawn(void* entry_point);
 task_small_t* task_spawn(void* entry_point);
 
+task_small_t* tasking_get_task_with_pid(int pid);
+task_small_t* tasking_get_current_task();
 #endif

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -31,7 +31,8 @@ typedef struct task_small {
 } task_small_t;
 
 void tasking_init_small();
-void task_switch_now();
 bool tasking_is_active();
+
+void task_switch();
 
 #endif

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -24,7 +24,6 @@ typedef struct task_small {
 	uint32_t current_timeslice_end_date;
 
 	uint32_t queue; //scheduler ring this task is slotted in
-	uint32_t relinquish_date;
 	uint32_t lifespan;
 
     uint32_t wake_timestamp; //used if process is in PIT_WAIT state

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -4,6 +4,15 @@
 #include <stdint.h>
 #include <kernel/multitasking/tasks/task.h>
 
+struct context {
+	uint32_t ebp;
+	uint32_t edi;
+	uint32_t esi;
+	uint32_t ebx;
+	uint32_t eax;
+	uint32_t eip;
+};
+
 typedef struct task_small {
 	char* name; //user-printable process name
 	int id;  //PID
@@ -19,9 +28,11 @@ typedef struct task_small {
 
 	uint32_t relinquish_date;
 	uint32_t lifespan;
-	struct task* next;
+	struct task_small_t* next;
 
     bool _has_run; //has the task ever been scheduled?
+
+	struct context* context;
 } task_small_t;
 
 void tasking_init_small();

--- a/src/kernel/multitasking/tasks/task_small.h
+++ b/src/kernel/multitasking/tasks/task_small.h
@@ -32,8 +32,8 @@ typedef struct task_small {
 	uint32_t queue; //scheduler ring this task is slotted in
 	uint32_t lifespan;
 
-    uint32_t wake_timestamp; //used if process is in PIT_WAIT state
 	bool is_thread;
+	vmm_pdir_t* vmm;
 } task_small_t;
 
 void tasking_init_small();

--- a/src/kernel/syscall/sysfuncs.c
+++ b/src/kernel/syscall/sysfuncs.c
@@ -19,7 +19,7 @@ void yield(task_state reason) {
 	//then it should not be blocked
 	//block_task would manage this itself, but we can skip block_task overhead by doing it here ourselves
 	if (reason == RUNNABLE) {
-		task_switch_now();
+		task_switch();
 		return;
 	}
 	panic("not runnable");

--- a/src/kernel/util/paging/paging.c
+++ b/src/kernel/util/paging/paging.c
@@ -170,7 +170,7 @@ vmm_pdir_t* vmm_clone_active_page_table_at_index(vmm_pdir_t* dst_dir, uint32_t t
 
 vmm_pdir_t* vmm_clone_active_pdir() {
     vmm_pdir_t* src = vmm_active_pdir();
-    printf("VMM cloning page directory 0x%08x\n", src);
+    printk("VMM cloning page directory 0x%08x\n", src);
     vmm_pdir_t* new_dir = vmm_setup_new_pdir();
 
     //copy each table
@@ -183,7 +183,7 @@ vmm_pdir_t* vmm_clone_active_pdir() {
         //TODO(PT) this will waste tables that only have a couple kernel pages
         //in use! do we care?
         if (new_dir->tablesPhysical[i]) {
-            printf("vmm_clone_pdir not copying already copied table index %d\n", i);
+            printk("vmm_clone_pdir not copying already copied table index %d\n", i);
             continue;
         }
 
@@ -194,7 +194,7 @@ vmm_pdir_t* vmm_clone_active_pdir() {
 
         vmm_clone_active_page_table_at_index(new_dir, i);
         new_dir->tables[i] = clone_table(pt, &table_phys);
-        printf("cloned table: 0x%08x phys 0x%08x\n", pt, table_phys);
+        printk("cloned table: 0x%08x phys 0x%08x\n", pt, table_phys);
         new_dir->tablesPhysical[i] = table_phys | 0x07;
     }
 

--- a/src/kernel/vmm/vmm.c
+++ b/src/kernel/vmm/vmm.c
@@ -193,6 +193,7 @@ static void _active_vmm_map_virt_to_phys(vmm_pdir_t* dir, uint32_t page_addr, ui
 
     unsigned long * pd = (unsigned long *)0xFFFFF000;
     //if the page table didn't already exist, alloc one
+    uint32_t* pt = (0xFFC00000 + (0x1000 * pdindex));
     if (!(pd[pdindex])) {
         uint32_t new_table_frame = pmm_alloc();
         pd[pdindex] = new_table_frame | 0x07; //present, rw, us
@@ -204,9 +205,10 @@ static void _active_vmm_map_virt_to_phys(vmm_pdir_t* dir, uint32_t page_addr, ui
             printf("dir 0x%08x arr 0x%08x\n eq %d", dir_frame, new_table_frame, (int)dir_frame==new_table_frame);
             panic("dir->tablesPhysical wasn't updated after assigning page table pointer");
         }
+        // immediately memset new table
+        printf("memsetting new page table at 0x%x\n", pt);
+        memset(pt, 0, PAGE_SIZE);
     }
-
-    unsigned long * pt = ((unsigned long *)0xFFC00000) + (0x400 * pdindex);
     // Here you need to check whether the PT entry is present.
     // When it is, then there is already a mapping present. What do you do now?
     if (pt[ptindex]) {

--- a/src/std/kheap.c
+++ b/src/std/kheap.c
@@ -171,6 +171,7 @@ static alloc_block_t* find_smallest_hole(uint32_t size, bool align, heap_t* heap
 
 void kheap_init() {
     boot_info_t* info = boot_info_get();
+	// XXX(PT): info->kernel_image_end is the region after the identity-map-protected region that the VMM and PMM coordinate.
     uint32_t start = info->kernel_image_end + 0x100000;
     uint32_t end_addr = start + KHEAP_INITIAL_SIZE;
     uint32_t max = end_addr;
@@ -258,6 +259,7 @@ void heap_verify_integrity() {
 }
 
 static void heap_expand(heap_t* heap, uint32_t expand_size) {
+	NotImplemented();
 	lock(mutex);
 
 	uint32_t curr_size = heap->end_address - heap->start_address;

--- a/src/std/kheap.c
+++ b/src/std/kheap.c
@@ -170,18 +170,18 @@ static alloc_block_t* find_smallest_hole(uint32_t size, bool align, heap_t* heap
 }
 
 void kheap_init() {
-    boot_info_t* info = boot_info_get();
+	boot_info_t *info = boot_info_get();
 	// XXX(PT): info->kernel_image_end is the region after the identity-map-protected region that the VMM and PMM coordinate.
-    uint32_t start = info->kernel_image_end + 0x100000;
-    uint32_t end_addr = start + KHEAP_INITIAL_SIZE;
-    uint32_t max = end_addr;
-    uint32_t max_size = max - start;
+	uint32_t start = info->kernel_image_end + 0x100000;
+	uint32_t end_addr = start + KHEAP_INITIAL_SIZE;
+	uint32_t max = end_addr;
+	uint32_t max_size = max - start;
 
 	//start and end MUST be page aligned
 	ASSERT(start % PAGING_PAGE_SIZE == 0, "start wasn't page aligned");
 	ASSERT(end_addr % PAGING_PAGE_SIZE == 0, "end_addr wasn't page aligned");
 
-    printf_info("Creating kernel heap at [0x%08x - 0x%08x]", start, end_addr);
+	printf_info("Creating kernel heap at [0x%08x - 0x%08x]", start, end_addr);
 
 	//write start, end, and max addresses into heap structure
 	kheap->start_address = start;
@@ -190,14 +190,14 @@ void kheap_init() {
 	kheap->supervisor = true;
 	kheap->readonly = false;
 
-    //map this memory into kernel page directory
-    vmm_map_region(vmm_active_pdir(), start, KHEAP_INITIAL_SIZE, PAGE_PRESENT_FLAG|PAGE_WRITE_FLAG);
+	//map this memory into kernel page directory
+	vmm_map_region(vmm_active_pdir(), start, KHEAP_INITIAL_SIZE, PAGE_PRESENT_FLAG | PAGE_WRITE_FLAG);
 
 	//we start off with one large free block
 	//this represents the whole heap at this point
 	create_block(start, end_addr - start);
 
-    info->heap_kernel = kheap;
+	info->heap_kernel = kheap;
 }
 
 void expand(uint32_t UNUSED(new_size), heap_t* UNUSED(heap)) {
@@ -265,7 +265,6 @@ static void heap_expand(heap_t* heap, uint32_t expand_size) {
 	uint32_t curr_size = heap->end_address - heap->start_address;
 	if (curr_size + expand_size >= heap->max_address) {
 		ASSERT(0, "Heap ran out of space!\n");
-		while (1) {}
 	}
 
 	alloc_block_t* curr = first_block(heap);

--- a/src/std/kheap.h
+++ b/src/std/kheap.h
@@ -26,7 +26,7 @@ void kmalloc_track_int(char* file, int line, uint32_t size);
 #define kmalloc(bytes) kmalloc_track(bytes)
 
 #define KHEAP_START			0xC0000000
-#define KHEAP_INITIAL_SIZE	0x000F0000
+#define KHEAP_INITIAL_SIZE	0x01F00000
 #define KHEAP_MAX_ADDRESS 	0xDFFFF000
 //#define KHEAP_MAX_ADDRESS 	0xCFFFF000
 

--- a/src/std/printf.c
+++ b/src/std/printf.c
@@ -361,6 +361,3 @@ int sprintf() {
 int output() {
     NotImplemented();
 }
-int reset_cursor_pos() {
-    NotImplemented();
-}

--- a/src/std/timer.c
+++ b/src/std/timer.c
@@ -89,13 +89,6 @@ void timer_callback_deliver_immediately(timer_callback_t* callback) {
 	callback->time_left = 0;
 }
 
-void sleep(uint32_t ms) {
-	uint32_t end = time() + ms;
-    extern task_t* current_task;
-    current_task->wake_timestamp = end;
-    sys_yield(PIT_WAIT);
-}
-
 void timer_init() {
 	int_notifier_register_callback(PIT_INT_VECTOR, _timer_handle_pit_tick, NULL, true);
 }

--- a/src/std/timer.h
+++ b/src/std/timer.h
@@ -17,14 +17,13 @@ typedef struct {
 	void* context;
 } timer_callback_t;
 
-STDAPI timer_callback_t* timer_add_callback(void* callback, int interval, bool repeats, void* context);
-STDAPI void timer_remove_callback(timer_callback_t* callback);
-STDAPI void timer_deliver_immediately(timer_callback_t* callback);
+STDAPI void timer_init();
+
+STDAPI timer_callback_t* timer_callback_register(void* callback, int interval, bool repeats, void* context);
+STDAPI void timer_callback_remove(timer_callback_t* callback);
+STDAPI void timer_callback_deliver_immediately(timer_callback_t* callback);
 
 STDAPI void sleep(uint32_t ms);
-
-//friend function for pit.c
-void _timer_handle_pit_tick();
 
 __END_DECLS
 

--- a/src/user/xserv/xserv.c
+++ b/src/user/xserv/xserv.c
@@ -209,7 +209,7 @@ Color color_rand() {
 }
 
 static Window* grabbed_window = NULL;
-void draw_desktop(Screen* screen) {
+void xserv_draw_desktop(Screen* screen) {
 	static int redraw_count = 0;
 
 	layer_clear_clip_rects(screen->vmem);
@@ -413,6 +413,7 @@ void draw_cursor(Screen* screen) {
 	}
 
 	draw_mouse_shadow(screen, last_mouse_pos, mouse_point());
+	last_mouse_pos = mouse_point();
 
 	dirtied = prev_dirtied;
 }
@@ -425,7 +426,7 @@ char xserv_draw(Screen* screen) {
 	screen->finished_drawing = 0;
 
 	dirtied = 0;
-	draw_desktop(screen);
+	xserv_draw_desktop(screen);
 	draw_cursor(screen);
 
 	screen->finished_drawing = 1;
@@ -751,6 +752,7 @@ void xserv_temp_stop(uint32_t pause_length) {
 void xserv_init() {
 	if (sys_fork()) return;
 
+	switch_to_vesa(0x118, true);
 	//become_first_responder();
 	Screen* screen = gfx_screen();
 	desktop_setup(screen);


### PR DESCRIPTION
Major changes:

* Deprecate existing multitasking code, and implement a new tasking system. `task_t` has been superseded by `task_small_t`. I have not removed existing `task_t` code so that it can be present for reference while enabling more preexisting kernel features, but all functions have been explicitly marked deprecated.

* Added a new system for invoking a callback when a specified interrupt vector is ran. Importantly, the callbacks are ran **after** the kernel's interrupt handling has completed. As a result of this, it is safe for these callbacks to do significant work: as the interrupt has been processed and the end-of-interrupt has been sent, it is safe for these callbacks to perform actions such as forcing a context switch. This system is mostly a copy of the timer callback system, with a hook into the global interrupt handler instead of into the PIT interrupt handler.

* Thanks to the above, the timer system has been split from the PIT interrupt handler.

* Mouse driver reenabled.