### PR TITLE
Interpolate points along glyphs

### DIFF
--- a/rust_programs/ttf_renderer/src/glyphs.rs
+++ b/rust_programs/ttf_renderer/src/glyphs.rs
@@ -589,7 +589,7 @@ fn points_for_polygon(
     let mut values = vec![];
 
     if !interpolate {
-        return points[start_index..=end_index].to_vec().clone();
+        return points[start_index..=end_index].to_vec();
     }
     
     /*

--- a/rust_programs/ttf_renderer/src/glyphs.rs
+++ b/rust_programs/ttf_renderer/src/glyphs.rs
@@ -610,11 +610,10 @@ fn points_for_polygon(
     let mut last_off_curve_value = 0;
     let mut last_value_was_on_curve = true;
 
-    
-    for index in start_index+1..=end_index {
-        let next_value = points[index];
-        let relative_value = next_value - last_value;
-        last_value = next_value;
+
+    for (index, next_value) in points[start_index+1..=end_index].iter().enumerate() {
+        let relative_value = *next_value - last_value;
+        last_value = *next_value;
         let flag_set = &flags[index];
             
         let next_pt_is_on_curve = flag_set.contains(&GlyphOutlineFlag::OnCurve);
@@ -623,7 +622,7 @@ fn points_for_polygon(
             if next_pt_is_on_curve {
                 // just add new point to the list of points (i.e. draw a
                 // straight line to the new point)
-                last_on_curve_value = next_value;
+                last_on_curve_value = *next_value;
                 values.push(last_on_curve_value);
             }
             else {

--- a/rust_programs/ttf_renderer/src/parser.rs
+++ b/rust_programs/ttf_renderer/src/parser.rs
@@ -436,10 +436,11 @@ impl<'a> FontParser<'a> {
             }
         }
 
-        let font_program_header = self.table_headers.get("fpgm").unwrap();
-        let font_program = self.read_bytes(font_program_header.offset, font_program_header.length);
+        if let Some(font_program_header) = self.table_headers.get("fpgm") {
+            let font_program = self.read_bytes(font_program_header.offset, font_program_header.length);
         //let graphics_state = GraphicsState::new();
-        parse_instructions(font_program, HintParseOperations::all());
+            parse_instructions(font_program, HintParseOperations::all());
+        }
 
         Font::new(
             // TODO(PT): Parse font names

--- a/rust_programs/ttf_renderer/src/render.rs
+++ b/rust_programs/ttf_renderer/src/render.rs
@@ -260,7 +260,9 @@ fn render_polygons_glyph(
     for instr in instructions.iter() {
         println!("instr {instr:02x}");
     }
-    parse_instructions(instructions, HintParseOperations::all())
+    if instructions.len() > 0 {
+        parse_instructions(instructions, HintParseOperations::all())
+    }
 }
 
 pub fn render_glyph_onto(

--- a/rust_programs/ttf_viewer/src/main_std.rs
+++ b/rust_programs/ttf_viewer/src/main_std.rs
@@ -40,9 +40,10 @@ pub fn main2() -> Result<(), Box<dyn error::Error>> {
 }
 
 pub fn main() -> Result<(), Box<dyn error::Error>> {
-    let font_path = "/Users/philliptennen/Documents/fonts/helvetica-2.ttf";
+    //let font_path = "/Users/philliptennen/Documents/fonts/helvetica-2.ttf";
+    let font_path = "/System/Library/Fonts/NewYorkItalic.ttf";
 
-    let font_size = Size::new(16, 16);
+    let font_size = Size::new(128, 128);
     let window_size = Size::new(1240, 1000);
     let window = Rc::new(AwmWindow::new("Hosted Font Viewer", window_size));
 
@@ -58,7 +59,7 @@ pub fn main() -> Result<(), Box<dyn error::Error>> {
     let font = parse(&font_data);
 
     //render_all_glyphs_in_font(&mut main_view_slice, &font, &font_size, Some(3000));
-    render_string(&mut main_view_slice, &font, &font_size, "axle");
+    //render_string(&mut main_view_slice, &font, &font_size, "axle");
     //render_glyph(&mut main_view_slice, &font.glyphs[2], 0.4, 0.4);
 
     window.enter_event_loop();


### PR DESCRIPTION
Adds a `points_for_polygon` function in `glyphs.rs` that interprets the flags for the points in the given indices and interpolates along any control points. Interpolation can be toggled in `parse_gylph()` via the flag `let interpolate = true;`. 

Currently two points are added for every control point, at `t=0.3` and `t=0.6` along the curve. A noticeable (if subtle) difference results:
![comparison2](https://user-images.githubusercontent.com/109662283/220259833-328c6259-a936-477f-9c9e-a46cd4c079c8.png)

Using more interpolated points is possible, however a quick test did not show an appreciable difference - in the next screenshot the top render used 4 points for each control points, at `t=0.2, 0,4, 0.6, 0.8`, the middle one used 2 control points (`t=0.3, 0.6`) and the bottom one used none:
![comparison3](https://user-images.githubusercontent.com/109662283/220260146-c8363222-fd58-48f1-afa8-cadd2cce10e7.png)
